### PR TITLE
Punctuation change on features page

### DIFF
--- a/features.html
+++ b/features.html
@@ -91,7 +91,7 @@
 				<section>
 					<article class="grid-5 alpha">
 						<h2>Easy to Learn</h2>
-						<p>Classes and ID's make sense. Finding it hard to learn a new framework. Centurion features easy to read markup, stylying elements makes sense based on what the usage is and it even comes fully documented (coming soon) so you can find what you need fast.</p>
+						<p>Classes and ID's make sense. Finding it hard to learn a new framework? Centurion features easy to read markup, stylying elements makes sense based on what the usage is and it even comes fully documented (coming soon) so you can find what you need fast.</p>
 					</article>
 		    	<article class="grid-3 omega">
 						<img src="graphics/book.jpg" class="hide-mobile" alt="feature" />


### PR DESCRIPTION
I noticed that this probably should be a question mark instead of a period.   

_"Finding it hard to learn a new framework. Centurion features easy to ..."_
