### PR TITLE
merging 3.6.2 into master for release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Project
-_build
-_releases
+release
+centurion-framework.zip
 *.gem
 
 ### Node ###

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.6.2
 - bug fix #27 when using `.ctn-center` would not center grid elements
 - Grunt Sass version updated in package.json to `1.1.0` to alleviate compile errors
+- Github releases added to Grunt
 
 ## 3.6.1
 - Autoprefixer added to Grunt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.6.2
 - bug fix #27 when using `.ctn-center` would not center grid elements
+- Grunt Sass version updated in package.json to `1.1.0` to alleviate compile errors
 
 ## 3.6.1
 - Autoprefixer added to Grunt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.6.2
+- bug fix #27 when using `.ctn-center` would not center grid elements
+
 ## 3.6.1
 - Autoprefixer added to Grunt
 - Flex Grid included as default

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you're concerned about browser support then we recommend either [html5shiv](h
 
 ## Versioning
 
-Current version: `3.6.1`
+Current version: `3.6.2`
 
 Centurion no longer supports Internet Explorer 7 as of version `3.5.3`.
 

--- a/lib/sass/centurion/_flex-grid.scss
+++ b/lib/sass/centurion/_flex-grid.scss
@@ -142,7 +142,7 @@ $gutter-half: 10px;
 // Flex Grid Row Adjustments
 // ----------------------------
 @mixin grid-flex-row-adjust() {
-  
+
   .#{$prefix-class}-full {
     align-content: stretch;
   }
@@ -163,13 +163,13 @@ $gutter-half: 10px;
   .#{$prefix-class}-between {
     justify-content: space-between;
   }
-  
-  
-    
+
+
+
   //@TODO: [] flex first and last for each media query
   //@TODO: [] flex reverse for each media query
   //@TODO: [] flex start, center, end for each media query
-  
+
   // move grid elment first or last
   .#{$prefix-class}-first {
     order: -1;
@@ -177,12 +177,12 @@ $gutter-half: 10px;
   .#{$prefix-class}-last {
     order: 1;
   }
-  
+
   // reverse order of row
   .#{$prefix-class}-reverse {
     flex-direction: row-reverse;
   }
-  
+
   // shift grid elements based on starting position
   .#{$prefix-class}-start {
     align-self: flex-start;
@@ -192,8 +192,9 @@ $gutter-half: 10px;
   }
   .#{$prefix-class}-center {
     align-self: center;
+    justify-content: center;
   }
-  
+
   @media screen and (max-width: $t-width + px) {
     .#{$t-grid-class}-first {
       order: -1;
@@ -214,7 +215,7 @@ $gutter-half: 10px;
       order: initial;
     }
   }
-  
+
   @media screen and (max-width: $m-width + px) {
     .#{$m-grid-class}-first {
       order: -1;
@@ -235,14 +236,14 @@ $gutter-half: 10px;
       order: initial;
     }
   }
-  
+
 }
 
 @mixin nested-flex-grid-elements($class: $grid-class) {
 
   //@TODO: [] nested reset for start, end, first, middle, and last for padding on grid elements
   //@TODO: [] needs to work with all media query grid layouts
-  
+
   .#{$row-class} {
     [class*=#{$class}]:first-of-type,
     .#{$prefix-class}-first,

--- a/package.json
+++ b/package.json
@@ -29,11 +29,9 @@
   "bugs": {
     "url": "https://github.com/justinhough/centurion/issues"
   },
-  "dependencies": {
-    "grunt": "^0.4.5"
-  },
   "devDependencies": {
     "autoprefixer-core": "^5.2.0",
+    "grunt": "^0.4.5",
     "grunt-banner": "^0.3.1",
     "grunt-concurrent": "^1.0.0",
     "grunt-contrib-clean": "^0.6.0",
@@ -47,7 +45,7 @@
     "grunt-include-replace": "^3.0.0",
     "grunt-newer": "^1.1.0",
     "grunt-postcss": "^0.5.1",
-    "grunt-sass": "^0.17.0",
+    "grunt-sass": "^1.1.0",
     "load-grunt-tasks": "^3.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,10 +41,12 @@
     "grunt-contrib-uglify": "^0.9.1",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-gh-pages": "^0.9.1",
+    "grunt-github-releaser": "^0.1.18",
     "grunt-http-server": "^1.4.0",
     "grunt-include-replace": "^3.0.0",
     "grunt-newer": "^1.1.0",
     "grunt-postcss": "^0.5.1",
+    "grunt-prompt": "^1.3.3",
     "grunt-sass": "^1.1.0",
     "load-grunt-tasks": "^3.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "centurion-framework",
   "projectName": "Centurion Framework",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "simpleDescription": "A Web Framework",
   "description": "Centurion is a web-based framework for rapid prototyping and provides a core for building larger web projects",
   "homepage": "http://www.centurionframework.com",


### PR DESCRIPTION
## Changes
- bug fix #27 when using `.ctn-center` would not center grid elements
- Grunt Sass version updated in package.json to `1.1.0` to alleviate compile errors
- Github releases added to Grunt